### PR TITLE
Fix duplicate command responses

### DIFF
--- a/help.py
+++ b/help.py
@@ -343,5 +343,8 @@ class HelpCog(commands.Cog):
                 await ctx.send(embed=embed)
 
 async def setup(bot: commands.Bot):
-    """Ajoute la classe HelpCog au bot."""
-    await bot.add_cog(HelpCog(bot))
+    """Ajoute la classe HelpCog au bot (une seule fois)."""
+    if bot.get_cog("HelpCog") is None:
+        await bot.add_cog(HelpCog(bot))
+    else:
+        print("[HelpCog] Déjà chargé, on ignore setup().")

--- a/job.py
+++ b/job.py
@@ -546,4 +546,8 @@ class JobCog(commands.Cog):
         await ctx.send(f"Salon console nettoyé, {deleted_count} messages supprimés.")
 
 async def setup(bot: commands.Bot):
-    await bot.add_cog(JobCog(bot))
+    """Ajoute JobCog une seule fois pour éviter les doublons."""
+    if bot.get_cog("JobCog") is None:
+        await bot.add_cog(JobCog(bot))
+    else:
+        print("[JobCog] Déjà chargé, on ignore setup().")


### PR DESCRIPTION
## Summary
- avoid loading JobCog and HelpCog twice

## Testing
- `python -m py_compile main.py job.py help.py`