### PR TITLE
Improve word moderation detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ Le fichier `job.py` permet aux joueurs d'enregistrer leurs professions. Les dern
 ## Modération automatique
 
 Le module `moderation.py` supprime les messages contenant des insultes graves,
-de la discrimination ou des menaces. L'auteur reçoit un avertissement en privé
-et l'incident est consigné dans le salon `𝐆𝐞́𝐧𝐞́𝐫𝐚𝐥-staff`. Après deux
+de la discrimination ou des menaces. Les mots surveillés sont détectés même si
+des espaces ou de la ponctuation sont insérés entre les lettres afin de
+contourner la modération. L'auteur reçoit un avertissement en privé et
+l'incident est consigné dans le salon `𝐆𝐞́𝐧𝐞́𝐫𝐚𝐥-staff`. Après deux
 avertissements, le membre est automatiquement sanctionné par un timeout d'une
 heure. Les commandes `!warnings` et `!resetwarnings` (réservées au rôle
 **Staff**) permettent de consulter ou remettre à zéro le compteur d'un membre.

--- a/ia.py
+++ b/ia.py
@@ -36,10 +36,20 @@ def chunk_list(txt, size=2000):
 
 def is_exact_match(msg: str, keyword: str) -> bool:
     """
-    Détecte si le 'keyword' est présent de façon isolée (mot entier) dans 'msg'.
+    Détecte si ``keyword`` est présent dans ``msg`` en ignorant les
+    séparateurs tels que les espaces ou la ponctuation.
+
+    Cette implémentation permet de bloquer les variantes comme ``pu te`` ou
+    ``pu!te`` tout en évitant les faux positifs lorsqu'un mot fait partie d'un
+    mot plus long.
     """
-    pattern = r"\b" + re.escape(keyword.lower()) + r"\b"
-    return re.search(pattern, msg) is not None
+
+    letters = re.sub(r"\W+", "", keyword.lower())
+    if not letters:
+        return False
+
+    pattern = r"(?<!\w)" + r"\W*".join(map(re.escape, letters)) + r"(?!\w)"
+    return re.search(pattern, msg.lower()) is not None
 
 ##############################################
 # Listes de mots-clés / intentions

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,0 +1,9 @@
+import ia
+
+
+def test_is_exact_match_variations():
+    assert ia.is_exact_match("pute", "pute")
+    assert ia.is_exact_match("pu te", "pute")
+    assert ia.is_exact_match("pu!te", "pute")
+    assert ia.is_exact_match("fil s de pu te", "fils de pute")
+    assert not ia.is_exact_match("computers", "pute")


### PR DESCRIPTION
## Summary
- catch obfuscated keywords in IA moderation logic
- document improved detection
- test `is_exact_match` on split/punctuated words

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_6855aee4a4e0832e8efe6214aa7c5e9b