### PR TITLE
Improve profanity detection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,3 +66,4 @@ urllib3==2.3.0
 validators==0.34.0
 Werkzeug==3.1.3
 yarl==1.18.3
+rapidfuzz==3.6.2

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -6,4 +6,6 @@ def test_is_exact_match_variations():
     assert ia.is_exact_match("pu te", "pute")
     assert ia.is_exact_match("pu!te", "pute")
     assert ia.is_exact_match("fil s de pu te", "fils de pute")
+    assert ia.is_exact_match("pût3", "pute")
+    assert ia.is_exact_match("filz de pute", "fils de pute")
     assert not ia.is_exact_match("computers", "pute")


### PR DESCRIPTION
## Summary
- add text normalization and fuzzy search using rapidfuzz
- detect insults in ModerationCog with the new logic
- add tests for accented and leetspeak variations
- require rapidfuzz library

## Testing
- `python -m py_compile ia.py moderation.py tests/test_detection.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError for `rapidfuzz`)*

------
https://chatgpt.com/codex/tasks/task_e_6855ba4c98d4832e9a295f6171b55ed0