### PR TITLE
Enhance profanity normalization tests

### DIFF
--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,3 +1,7 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import ia
 
 
@@ -8,4 +12,7 @@ def test_is_exact_match_variations():
     assert ia.is_exact_match("fil s de pu te", "fils de pute")
     assert ia.is_exact_match("pût3", "pute")
     assert ia.is_exact_match("filz de pute", "fils de pute")
+    assert ia.is_exact_match("pu7e", "pute")
+    assert ia.is_exact_match("pûtë", "pute")
+    assert ia.is_exact_match("p\u0302u\u0308t\u0301e", "pute")
     assert not ia.is_exact_match("computers", "pute")


### PR DESCRIPTION
## Summary
- extend profanity tests to cover digits, accents and combining marks
- make test file import target module reliably
- broaden leet speak support in `normalize_profanity`
- stub optional runtime deps and fall back to pure python Levenshtein
- refine `is_exact_match` to check whole normalized tokens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bb9f12d0832e8b3c04bc0094fcde