### PR TITLE
Add interactive event creation cog

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ async def main():
         "calcul",
         "defender",
         "moderation",
+        "event_conversation",
 
 
 


### PR DESCRIPTION
## Summary
- build new `event_conversation` cog for DM-based event creation
- load the cog in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859c0dc43e4832e8c92aa79afd0b89f