### PR TITLE
Add EventData JSON parsing tests

### DIFF
--- a/tests/test_event_data.py
+++ b/tests/test_event_data.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import json
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from models import EventData
+
+
+@pytest.mark.asyncio
+async def test_eventdata_valid_json():
+    json_text = json.dumps({
+        "guild_id": 123,
+        "channel_id": 456,
+        "title": "Test Event",
+        "description": "A test returned by Gemini",
+        "starts_at": "2025-01-01T12:00:00",
+        "ends_at": "2025-01-01T13:00:00",
+        "max_participants": 10
+    })
+    data = EventData.model_validate_json(json_text)
+    assert data.guild_id == 123
+    assert data.channel_id == 456
+    assert data.title == "Test Event"
+    assert data.max_participants == 10
+
+
+@pytest.mark.asyncio
+async def test_eventdata_invalid_json():
+    bad_json = '{"guild_id": 123,'  # malformed JSON
+    with pytest.raises(Exception):
+        EventData.model_validate_json(bad_json)


### PR DESCRIPTION
## Summary
- add pytest tests for parsing `EventData` from Gemini JSON

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685b06f880c0832e8eda4852bb5e6159