### PR TITLE
Fix discord package selection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ colorama==0.4.6
 contourpy==1.3.1
 cryptography==44.0.0
 cycler==0.12.1
-discord==2.3.2
 discord.py==2.4.0
 Flask==3.1.0
 fonttools==4.56.0
@@ -45,7 +44,6 @@ pluggy==1.5.0
 propcache==0.2.1
 proto-plus==1.26.0
 protobuf==5.29.3
-py-cord==2.6.1
 pyasn1==0.6.1
 pyasn1_modules==0.4.1
 pycparser==2.22


### PR DESCRIPTION
## Summary
- keep only `discord.py` as the Discord library
- remove `discord` and `py-cord` from requirements

## Testing
- `pytest -q` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685b1af7abfc832eb1989a3618749c90