### PR TITLE
Update deployment details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This repository hosts the Discord bot for the EVOLUTION guild. The bot is deployed on a free `render.com` micro instance and kept alive via a small Flask server (`alive.py`) that is pinged by **UptimeRobot**. Because render.com's free tier provides only ephemeral storage, all data not persisted directly on Discord (such as the JSON files sent to the `#console` channel) is lost every time the bot restarts. Agents working on this project should keep this limitation in mind and avoid relying on local persistence.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Lancez ensuite le bot avec :
 ```bash
 python main.py
 ```
+## Hébergement et persistance
+
+Le bot fonctionne sur un micro serveur gratuit hébergé chez [render.com](https://render.com). Un petit serveur Flask défini dans `alive.py` est régulièrement pingé par **UptimeRobot** afin de le maintenir éveillé. Comme cet hébergement ne propose qu'un stockage éphémère, toutes les données enregistrées localement sont perdues à chaque redémarrage. Seules les informations sauvegardées sur Discord (par exemple dans le salon `#console`) sont conservées.
+
 
 ## Module Job
 


### PR DESCRIPTION
## Summary
- note render.com & UptimeRobot hosting in the README
- add agent instructions about ephemeral storage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685c3330ef44832eb982407d74ddfa01