### PR TITLE
Ask for event duration if missing

### DIFF
--- a/tests/test_parse_duration.py
+++ b/tests/test_parse_duration.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from datetime import timedelta
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from utils import parse_duration
+
+
+def test_parse_duration_hours():
+    assert parse_duration("2h") == timedelta(hours=2)
+
+
+def test_parse_duration_hh_mm():
+    assert parse_duration("01:30") == timedelta(hours=1, minutes=30)
+
+
+def test_parse_duration_invalid():
+    with pytest.raises(ValueError):
+        parse_duration("abc")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,34 @@
+
+import re
+from datetime import timedelta
+
+__all__ = ["parse_duration"]
+
+
+def parse_duration(text: str) -> timedelta:
+    """Parse a short duration expression into a ``timedelta``.
+
+    Supported formats include ``"2h"`` or ``"01:30"`` for one hour
+    and thirty minutes.
+    """
+
+    t = text.strip().lower()
+
+    if ":" in t:
+        try:
+            hours, minutes = t.split(":", 1)
+            return timedelta(hours=int(hours), minutes=int(minutes))
+        except Exception as exc:
+            raise ValueError(f"Invalid duration: {text}") from exc
+
+    match = re.fullmatch(r"(?:(\d+)\s*h)?\s*(?:(\d+)\s*(?:m|min)?)?", t)
+    if not match:
+        raise ValueError(f"Invalid duration: {text}")
+
+    hours = int(match.group(1) or 0)
+    minutes = int(match.group(2) or 0)
+
+    if hours == 0 and minutes == 0:
+        raise ValueError(f"Invalid duration: {text}")
+
+    return timedelta(hours=hours, minutes=minutes)


### PR DESCRIPTION
## Summary
- prompt user for event duration if Gemini didn't provide an end time
- implement `parse_duration` utility
- add tests for duration parsing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685c3e3bbe10832e9a96e217f359cb4c