### PR TITLE
Add parse_duration utility

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,34 +1,7 @@
 
-import re
-from datetime import timedelta
+"""Utility helpers used across the bot."""
+
+from .datetime_utils import parse_duration
 
 __all__ = ["parse_duration"]
 
-
-def parse_duration(text: str) -> timedelta:
-    """Parse a short duration expression into a ``timedelta``.
-
-    Supported formats include ``"2h"`` or ``"01:30"`` for one hour
-    and thirty minutes.
-    """
-
-    t = text.strip().lower()
-
-    if ":" in t:
-        try:
-            hours, minutes = t.split(":", 1)
-            return timedelta(hours=int(hours), minutes=int(minutes))
-        except Exception as exc:
-            raise ValueError(f"Invalid duration: {text}") from exc
-
-    match = re.fullmatch(r"(?:(\d+)\s*h)?\s*(?:(\d+)\s*(?:m|min)?)?", t)
-    if not match:
-        raise ValueError(f"Invalid duration: {text}")
-
-    hours = int(match.group(1) or 0)
-    minutes = int(match.group(2) or 0)
-
-    if hours == 0 and minutes == 0:
-        raise ValueError(f"Invalid duration: {text}")
-
-    return timedelta(hours=hours, minutes=minutes)

--- a/utils/datetime_utils.py
+++ b/utils/datetime_utils.py
@@ -1,0 +1,28 @@
+"""Date and time helper utilities."""
+
+from __future__ import annotations
+
+import re
+from datetime import timedelta
+
+
+def parse_duration(s: str) -> timedelta:
+    """Convert short duration expressions into a :class:`timedelta`.
+
+    Supported formats include ``"2h"``, ``"1:30"`` or ``"90m"``.
+    """
+
+    s = s.strip().lower()
+
+    if match := re.fullmatch(r"(\d+):(\d\d)", s):
+        hours, minutes = map(int, match.groups())
+        return timedelta(hours=hours, minutes=minutes)
+
+    if s.endswith("h"):
+        return timedelta(hours=int(s[:-1]))
+
+    if s.endswith("m"):
+        return timedelta(minutes=int(s[:-1]))
+
+    raise ValueError("Format de durée inconnu")
+


### PR DESCRIPTION
## Summary
- add `parse_duration` helper under `utils/datetime_utils.py`
- re-export `parse_duration` from `utils.__init__`

## Testing
- `pytest tests/test_parse_duration.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install -q -r requirements.txt` *(fails due to missing internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685c40951210832e962ed5e9a8de0c88