### PR TITLE
Add event start and end fields to announcement embed

### DIFF
--- a/event_conversation.py
+++ b/event_conversation.py
@@ -303,6 +303,16 @@ class EventConversationCog(commands.Cog):
             return
 
         announce = event.to_embed()
+        announce.add_field(
+            name="Début",
+            value=start.strftime("%d/%m/%Y %H:%M"),
+            inline=False,
+        )
+        announce.add_field(
+            name="Fin",
+            value=end.strftime("%d/%m/%Y %H:%M"),
+            inline=False,
+        )
         announce.set_footer(text="Réagissez avec les boutons ci-dessous pour vous inscrire")
         view_rsvp = RSVPView(role)
         await target_chan.send(embed=announce, view=view_rsvp)


### PR DESCRIPTION
## Summary
- show the event start and end dates in the announcement embed

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685c4a985c74832e850c102b8c1a1543