### PR TITLE
Update python-dateutil dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ pydantic_core==2.27.2
 pyparsing==3.2.1
 pytest==8.3.5
 pytest-asyncio==0.26.0
-python-dateutil==2.9.0.post0
+python-dateutil>=2.9.0
 python-dotenv==1.0.1
 requests==2.32.3
 rsa==4.9


### PR DESCRIPTION
## Summary
- relax python-dateutil version requirement in `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685c513ac7a8832e875e2e60fb8f86a9