### PR TITLE
Fix duplicate event command

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,7 +74,7 @@ async def main():
         "defender",
         "moderation",
         "event_conversation",
-        "slash_events",
+        # "slash_events",  # disabled: duplicate with event_conversation
     ]
 
     for ext in extensions:


### PR DESCRIPTION
## Summary
- disable old `slash_events` cog to remove double responses when creating events

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685dae946f90832e9dc46383b07bebf9