### PR TITLE
Fix from_dict compatibility for pydantic v1

### DIFF
--- a/models/event_data.py
+++ b/models/event_data.py
@@ -39,7 +39,9 @@ if _HAS_PYDANTIC:
                     data["max_participants"] = min(int(mp), 8)
                 except (TypeError, ValueError):
                     data["max_participants"] = None
-            return cls.model_validate(data)
+            if hasattr(cls, "model_validate"):
+                return cls.model_validate(data)
+            return cls.parse_obj(data)
 
         @classmethod
         def model_validate_json(cls, json_str: str) -> "EventData":


### PR DESCRIPTION
## Summary
- improve `EventData.from_dict` to fall back to `parse_obj` when `model_validate` isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860132544c0832e98d97b62134a38a0