### PR TITLE
fix: add missing logging import

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import asyncio
+import logging
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv


### PR DESCRIPTION
## Summary
- add logging import to main.py

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68606a61f1c8832e8e1087b406fcadef