### PR TITLE
fix: tolerate missing console channel in event cog

### DIFF
--- a/event_conversation.py
+++ b/event_conversation.py
@@ -274,10 +274,15 @@ class EventConversationCog(commands.Cog):
 
     async def cog_load(self) -> None:
         self.console = ConsoleStore(self.bot, channel_name="console")
-        await self.console.load_all()      # pré-charge les events
+        try:
+            await self.console.load_all()      # pré-charge les events
+        except RuntimeError:
+            self.log.warning(
+                "Console channel not found; disabling console persistence.")
+            self.console = None
         await self.store.connect()
         # Restauration des RSVPView après reboot
-        records = (await self.console.load_all()).values()
+        records = (await self.console.load_all()).values() if self.console else []
         for rec in records:
             # skip events passés (> 1 jour après fin)
             if "message_id" not in rec:


### PR DESCRIPTION
## Summary
- gracefully handle missing console channel in `EventConversationCog.cog_load`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68606adc5478832e8f8352fbac13559a