### PR TITLE
Remove unused import causing load failure

### DIFF
--- a/event_conversation.py
+++ b/event_conversation.py
@@ -19,7 +19,6 @@ from discord.ext import commands, tasks
 from zoneinfo import ZoneInfo
 
 from models import EventData
-from utils.datetime_utils import parse_french_datetime
 from utils.console_store import ConsoleStore
 from utils.storage import EventStore
 


### PR DESCRIPTION
## Summary
- remove obsolete `parse_french_datetime` import from `event_conversation.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607e6979ac832e8238b98cea0249d7