### PR TITLE
Add parse_french_datetime alias

### DIFF
--- a/tests/test_parse_fr_datetime.py
+++ b/tests/test_parse_fr_datetime.py
@@ -4,7 +4,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from datetime import timezone
 from zoneinfo import ZoneInfo
-from utils import parse_fr_datetime
+from utils import parse_fr_datetime, parse_french_datetime
 
 
 def test_parse_french_weekday_hour():
@@ -13,4 +13,10 @@ def test_parse_french_weekday_hour():
     assert dt.tzinfo is timezone.utc
     paris = ZoneInfo("Europe/Paris")
     assert dt.astimezone(paris).hour == 21
+
+
+def test_parse_french_datetime_alias():
+    dt_alias = parse_french_datetime("samedi 21h")
+    dt_ref = parse_fr_datetime("samedi 21h")
+    assert dt_alias == dt_ref
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,7 +1,11 @@
 
 """Utility helpers used across the bot."""
 
-from .datetime_utils import parse_duration, parse_fr_datetime
+from .datetime_utils import (
+    parse_duration,
+    parse_fr_datetime,
+    parse_french_datetime,
+)
 
-__all__ = ["parse_duration", "parse_fr_datetime"]
+__all__ = ["parse_duration", "parse_fr_datetime", "parse_french_datetime"]
 

--- a/utils/datetime_utils.py
+++ b/utils/datetime_utils.py
@@ -81,3 +81,9 @@ def parse_fr_datetime(txt: str) -> datetime | None:
 
     return dt.astimezone(timezone.utc) if dt else None
 
+
+def parse_french_datetime(txt: str) -> datetime | None:
+    """Alias for :func:`parse_fr_datetime` (preferred)."""
+
+    return parse_fr_datetime(txt)
+


### PR DESCRIPTION
## Summary
- add `parse_french_datetime` wrapper
- export alias from `utils`
- test the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68608170b938832e9edb76edf93ad9b4