### PR TITLE
Fix start time check for events

### DIFF
--- a/event_conversation.py
+++ b/event_conversation.py
@@ -310,7 +310,7 @@ class EventConversationCog(commands.Cog):
 
         # ----- vérifs -----
         now = discord.utils.utcnow()
-        if draft.start_time <= now + MIN_DELTA:
+        if draft.start_time < now + MIN_DELTA:
             return await dm.send("⚠️ La date de début doit être au moins 5 minutes dans le futur.")
         if draft.end_time <= draft.start_time:
             return await dm.send("⚠️ L’heure de fin doit être après l’heure de début.")


### PR DESCRIPTION
## Summary
- allow event start times exactly five minutes in the future

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860802da7ac832e915f0829765fa633