### PR TITLE
Persist stats to Discord console channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ première exécution du bot. Ils sont enregistrés à côté des modules Python 
 sont donc pas suivis par Git. À chaque sauvegarde, leur contenu est également
 publié dans le salon `console` pour servir de sauvegarde distante.
 
+Le module de statistiques conserve lui aussi son état dans ce salon : un message
+épinglé contient le JSON complet et est mis à jour régulièrement. Le fichier
+`stats_data.json` n'est donc qu'un cache local provisoire.
+
 Des exemples anonymisés sont fournis dans le répertoire
 [`examples`](examples/) pour illustrer le format attendu de chaque fichier.
 

--- a/tests/test_stats_store.py
+++ b/tests/test_stats_store.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import json
+import asyncio
+import types
+
+# Insert repo root in path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Fake discord module for StatsStore
+fake_discord = sys.modules.setdefault("discord", types.ModuleType("discord"))
+fake_discord.Client = object
+
+class _Message:
+    def __init__(self, content="", author=None):
+        self.content = content
+        self.author = author
+        self.pinned = False
+    async def edit(self, *, content=None):
+        if content is not None:
+            self.content = content
+    async def pin(self, *, reason=None):
+        self.pinned = True
+
+class _Channel:
+    def __init__(self, name="console", messages=None, bot_user=None):
+        self.name = name
+        self._messages = list(messages or [])
+        self.bot_user = bot_user
+    async def history(self, limit=200):
+        for m in list(self._messages):
+            yield m
+    async def send(self, content):
+        m = _Message(content, author=self.bot_user)
+        self._messages.insert(0, m)
+        return m
+
+class _Utils:
+    @staticmethod
+    def get(iterable, **attrs):
+        for item in iterable:
+            if all(getattr(item, k, None) == v for k, v in attrs.items()):
+                return item
+        return None
+
+    @staticmethod
+    def utcnow():
+        import datetime
+        return datetime.datetime.utcnow()
+
+fake_discord.Message = _Message
+fake_discord.TextChannel = _Channel
+fake_discord.Forbidden = type("Forbidden", (Exception,), {})
+fake_discord.NotFound = type("NotFound", (Exception,), {})
+fake_discord.utils = _Utils
+
+from utils.stats_store import StatsStore
+
+class _Bot:
+    def __init__(self, channel):
+        self._channel = channel
+        self.user = object()
+        channel.bot_user = self.user
+    def get_all_channels(self):
+        return [self._channel]
+
+
+def test_stats_store_save_and_load(tmp_path):
+    chan = _Channel()
+    bot = _Bot(chan)
+    store = StatsStore(bot, tmp_path / "stats.json")
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(store.save({"val": 1}))
+    assert len(chan._messages) == 1
+    msg = chan._messages[0]
+    assert msg.pinned
+    with open(tmp_path / "stats.json", encoding="utf-8") as f:
+        assert json.load(f)["val"] == 1
+
+    store2 = StatsStore(bot, tmp_path / "stats.json")
+    loaded = loop.run_until_complete(store2.load())
+    assert loaded == {"val": 1}
+    assert store2._msg is msg
+
+    loaded["val"] = 2
+    loop.run_until_complete(store2.save(loaded))
+    with open(tmp_path / "stats.json", encoding="utf-8") as f:
+        assert json.load(f)["val"] == 2
+    assert len(chan._messages) == 1
+    assert "\n  \"val\": 2" in msg.content

--- a/utils/stats_store.py
+++ b/utils/stats_store.py
@@ -1,0 +1,59 @@
+import json
+import logging
+import discord
+
+log = logging.getLogger(__name__)
+CODEBLOCK = "```stats"
+
+
+class StatsStore:
+    """Persist stats data in a pinned message inside #console."""
+
+    def __init__(self, bot: discord.Client, file_path: str, channel_name: str = "console"):
+        self.bot = bot
+        self.file_path = file_path
+        self.channel_name = channel_name
+        self._msg: discord.Message | None = None
+
+    async def _channel(self) -> discord.TextChannel | None:
+        chan = discord.utils.get(self.bot.get_all_channels(), name=self.channel_name)
+        if chan is None:
+            log.warning("Canal #%s introuvable – persistance désactivée", self.channel_name)
+        return chan
+
+    async def load(self) -> dict | None:
+        chan = await self._channel()
+        if chan is None:
+            return None
+        async for msg in chan.history(limit=200):
+            if msg.author == self.bot.user and msg.content.startswith(CODEBLOCK):
+                try:
+                    data = json.loads(msg.content[len(CODEBLOCK):].strip("` \n"))
+                    self._msg = msg
+                    return data
+                except Exception:
+                    log.warning("Message stats mal formé (id=%s)", msg.id)
+        return None
+
+    async def save(self, data: dict) -> None:
+        chan = await self._channel()
+        if chan is None:
+            return
+        json_block = f"{CODEBLOCK}\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
+        if self._msg is None:
+            self._msg = await chan.send(json_block)
+            try:
+                await self._msg.pin(reason="Persistance statistiques")
+            except discord.Forbidden:
+                log.warning("Impossible d'épingler le message #console (permissions).")
+        else:
+            try:
+                await self._msg.edit(content=json_block)
+            except discord.NotFound:
+                self._msg = None
+                return await self.save(data)
+        try:
+            with open(self.file_path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2, ensure_ascii=False)
+        except Exception as e:
+            log.warning("Erreur sauvegarde fichier stats: %s", e)


### PR DESCRIPTION
## Summary
- persist stats data in a pinned message using new `StatsStore`
- load stats from that message on cog startup
- update README to explain stats persistence
- add regression tests for the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68617bde670c832e91cd7f1bdcf62beb