### PR TITLE
Fix console data load duplication

### DIFF
--- a/event_conversation.py
+++ b/event_conversation.py
@@ -242,10 +242,12 @@ class EventConversationCog(commands.Cog):
     # ---------- lifecycle ------------------------------------------------- #
     async def cog_load(self) -> None:
         self.console = ConsoleStore(self.bot, channel_name="console")
-        if await self.console._channel() is not None:
-            await self.console.load_all()
-        # restaure les RSVP après reboot
-        for rec in (await self.console.load_all()).values() if self.console else []:
+        chan = await self.console._channel()
+        if chan is None:
+            return
+
+        records = await self.console.load_all()
+        for rec in records.values():
             await self._restore_view(rec)
 
     # --------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- load ConsoleStore entries only once during `cog_load`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f5543760832ea23280eb178c6051