### PR TITLE
Fix IA command initialization and update API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Clonez ce dépôt puis installez les dépendances :
 pip install -r requirements.txt
 ```
 
-Créez ensuite un fichier `.env` contenant au minimum votre `DISCORD_TOKEN`, la clé `GEMINI_API_KEY` pour l'IA et une `FERNET_KEY` utilisée par `defender.py` pour chiffrer les URL. Cette clé est **obligatoire** et doit être fournie via la variable d'environnement `FERNET_KEY` (par exemple `FERNET_KEY=...`).
+Créez ensuite un fichier `.env` contenant au minimum votre `DISCORD_TOKEN`, la clé `GOOGLE_API_KEY` pour l'IA et une `FERNET_KEY` utilisée par `defender.py` pour chiffrer les URL. Cette clé est **obligatoire** et doit être fournie via la variable d'environnement `FERNET_KEY` (par exemple `FERNET_KEY=...`).
 Vous pouvez générer cette clé avec :
 
 ```bash

--- a/event_conversation.py
+++ b/event_conversation.py
@@ -15,8 +15,16 @@ from typing import Any, Dict, List, Optional
 
 import dateparser
 import discord
-if not hasattr(discord.utils, "evaluate_annotation"):
-    discord.utils.evaluate_annotation = lambda *a, **k: None
+
+
+def _ensure_utils() -> None:
+    if not hasattr(discord.utils, "evaluate_annotation"):
+        discord.utils.evaluate_annotation = lambda *a, **k: None
+    if not hasattr(discord.utils, "is_inside_class"):
+        discord.utils.is_inside_class = lambda obj: False
+
+
+_ensure_utils()
 from discord.ext import commands, tasks
 from zoneinfo import ZoneInfo
 
@@ -228,6 +236,10 @@ class RSVPView(discord.ui.View):
 # --------------------------------------------------------------------------- #
 
 class EventConversationCog(commands.Cog):
+    def __new__(cls, *args, **kwargs):
+        _ensure_utils()
+        return super().__new__(cls)
+
     def __init__(
         self,
         bot: commands.Bot,

--- a/ia.py
+++ b/ia.py
@@ -357,10 +357,6 @@ class IACog(commands.Cog):
         self.active_chats = {}         # user_id ➜ genai.Chat
         self.SESSION_TTL = 60 * 30   # 30 min d’inactivité
 
-        # On lance la loop "process_queue" (mais elle démarrera
-        # réellement après le cog_load, selon Discord.py).
-        self.process_queue.start()
-
     async def cog_load(self):
         """
         Méthode appelée automatiquement par discord.py quand le Cog est chargé.
@@ -391,9 +387,7 @@ class IACog(commands.Cog):
         Charge la clé d'API et prépare les modèles Generative AI.
         """
         load_dotenv()
-        self.api_key = os.getenv("GEMINI_API_KEY")
-        if not self.api_key:
-            raise ValueError("Missing GEMINI_API_KEY dans .env.")
+        self.api_key = os.environ["GOOGLE_API_KEY"]
         genai.configure(api_key=self.api_key)
         self.model_pro = genai.GenerativeModel("gemini-1.5-pro")
         self.model_flash = genai.GenerativeModel("gemini-1.5-flash")
@@ -974,4 +968,6 @@ async def setup(bot: commands.Bot):
     Méthode appelée par bot.load_extension(...).
     Ajoute simplement le IACog au bot.
     """
-    await bot.add_cog(IACog(bot))
+    cog = IACog(bot)
+    await bot.add_cog(cog)
+    cog.process_queue.start()


### PR DESCRIPTION
## Summary
- configure Gemini using `GOOGLE_API_KEY` and start request queue in Cog setup
- document new `GOOGLE_API_KEY` env var in README
- harden event conversation cog for missing `discord.utils` helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689110eb4564832e864e4c5173cd1f2d