### PR TITLE
Use plain console channel name

### DIFF
--- a/activite.py
+++ b/activite.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 # Noms de canaux / rôles
 ORGA_CHANNEL_NAME = "🌈 organisation 🌈"
-CONSOLE_CHANNEL_NAME = "🎮 console 🎮"
+CONSOLE_CHANNEL_NAME = "console"
 VALIDATED_ROLE_NAME = "Membre validé d'Evolution"
 
 # Fichier de persistance

--- a/event_conversation.py
+++ b/event_conversation.py
@@ -255,7 +255,7 @@ class EventConversationCog(commands.Cog):
 
     # ---------- lifecycle ------------------------------------------------- #
     async def cog_load(self) -> None:
-        self.console = ConsoleStore(self.bot, channel_name="🎮 console 🎮")
+        self.console = ConsoleStore(self.bot, channel_name="console")
         chan = await self.console._channel()
         if chan is None:
             return

--- a/ia.py
+++ b/ia.py
@@ -52,7 +52,7 @@ class IASession:
     def expired(self) -> bool:
         return datetime.utcnow() - self.start_ts > timedelta(minutes=60)
 
-CONSOLE_CHANNEL_NAME = "🎮 console 🎮"
+CONSOLE_CHANNEL_NAME = "console"
 QUEUE_PROCESS_INTERVAL = 5
 
 def chunk_list(txt, size=2000):

--- a/job.py
+++ b/job.py
@@ -10,7 +10,7 @@ import discord
 from discord.ext import commands, tasks
 from collections import defaultdict
 
-CONSOLE_CHANNEL_NAME = "🎮 console 🎮"
+CONSOLE_CHANNEL_NAME = "console"
 DATA_FILE = os.path.join(os.path.dirname(__file__), "jobs_data.json")
 STAFF_ROLE_NAME = "Staff"
 JOB_MIN_LEVEL = 1

--- a/main.py
+++ b/main.py
@@ -145,7 +145,7 @@ class EvoBot(commands.Bot):
         start = time.time()
         while time.time() - start < timeout:
             for g in self.guilds:
-                ch = discord.utils.get(g.text_channels, name="🎮 console 🎮")
+                ch = discord.utils.get(g.text_channels, name="console")
                 if ch:
                     return ch
             await asyncio.sleep(1)
@@ -167,7 +167,7 @@ class EvoBot(commands.Bot):
     async def acquire_leadership(self):
         ch = await self.wait_console_channel(timeout=30)
         if not ch:
-            logging.warning("Salon #🎮 console 🎮 introuvable: pas de lock distribué, on continue.")
+            logging.warning("Salon #console introuvable: pas de lock distribué, on continue.")
             return True
         my = await ch.send(f"{LOCK_TAG} {self.INSTANCE_ID} {int(time.time())}")
         self._lock_channel_id = ch.id

--- a/players.py
+++ b/players.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from urllib.parse import urlparse
 
 DATA_FILE = os.path.join(os.path.dirname(__file__), "players_data.json")
-CONSOLE_CHANNEL_NAME = "🎮 console 🎮"
+CONSOLE_CHANNEL_NAME = "console"
 PLAYERS_MARKER = "===PLAYERSDATA==="
 
 def charger_donnees() -> Dict[str, dict]:

--- a/tests/test_stats_store.py
+++ b/tests/test_stats_store.py
@@ -23,7 +23,7 @@ class _Message:
         self.pinned = True
 
 class _Channel:
-    def __init__(self, name="🎮 console 🎮", messages=None, bot_user=None):
+    def __init__(self, name="console", messages=None, bot_user=None):
         self.name = name
         self._messages = list(messages or [])
         self.bot_user = bot_user

--- a/up.py
+++ b/up.py
@@ -13,7 +13,7 @@ VALID_MEMBER_ROLE_NAME = "Membre validé d'Evolution"
 INVITE_ROLE_NAME = "Invité"
 VETERAN_ROLE_NAME = "Vétéran"
 STAFF_CHANNEL_NAME = "📊 Général-staff 📊"
-CONSOLE_CHANNEL_NAME = "🎮 console 🎮"  # <-- canal console, identique à job.py
+CONSOLE_CHANNEL_NAME = "console"  # <-- canal console, identique à job.py
 BOTUP_TAG = "===BOTUP==="         # <-- marqueur spécial pour retrouver le JSON
 MESSAGE_THRESHOLD = 20
 JOINED_THRESHOLD_DAYS = 6 * 30

--- a/utils/console_store.py
+++ b/utils/console_store.py
@@ -9,9 +9,9 @@ CODEBLOCK = "```event"
 
 
 class ConsoleStore:
-    """Petite « base » : chaque événement est sauvegardé dans #🎮 console 🎮."""
+    """Petite « base » : chaque événement est sauvegardé dans #console."""
 
-    def __init__(self, bot: discord.Client, channel_name: str = "🎮 console 🎮"):
+    def __init__(self, bot: discord.Client, channel_name: str = "console"):
         self.bot = bot
         self.channel_name = channel_name
         self._cache: dict[int, dict] = {}          # event_id -> dict enrichi + _msg

--- a/utils/stats_store.py
+++ b/utils/stats_store.py
@@ -10,7 +10,7 @@ import discord
 log = logging.getLogger("utils.stats_store")
 
 class StatsStore:
-    def __init__(self, bot, channel_name="🎮 console 🎮"):
+    def __init__(self, bot, channel_name="console"):
         self.bot = bot
         self.channel_name = channel_name
         self._msg = None

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -16,7 +16,7 @@ class EventStore:
 
     MARKER = "===EVENTSTORE==="
 
-    def __init__(self, bot: commands.Bot, console_channel: str = "🎮 console 🎮"):
+    def __init__(self, bot: commands.Bot, console_channel: str = "console"):
         self.bot = bot
         self.console_channel_name = console_channel
         self.console_channel: Optional[discord.TextChannel] = None


### PR DESCRIPTION
## Summary
- Replace all `🎮 console 🎮` references with `console`
- Default helper utilities and tests to the new channel name
- Adjust logging to look up `#console`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abbe432284832e9223fffd8dc4a693