### PR TITLE
Add interactive announcement command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Pour que toutes les fonctionnalités fonctionnent correctement, le serveur doit 
 ### Salons textuels attendus
 - `console` : salon privé où le bot sauvegarde/charge ses fichiers JSON.
 - `ticket` : réception des tickets créés avec la commande `!ticket`.
-- `annonces` : utilisé par `!annonce` et pour les sondages.
+- `annonces` : utilisé par `!annonce`, `!*annonce` et pour les sondages.
 - `organisation` : pour la planification d'activités via `!activite`.
 - `𝐆𝐞́𝐧𝐞́𝐫𝐚𝐥` : canal public où le bot poste un message si les DM sont bloqués.
 - `𝐑𝐞𝐜𝐫𝐮𝐭𝐞𝐦𝐞𝐧𝐭` : annonces d'entrées ou de départs de la guilde.

--- a/annonce.py
+++ b/annonce.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import asyncio
+import discord
+from discord.ext import commands
+
+try:
+    from openai import AsyncOpenAI
+except Exception:
+    AsyncOpenAI = None
+
+STAFF_ROLE_NAME = os.getenv("IASTAFF_ROLE", "Staff")
+ANNONCE_CHANNEL = "📣 annonces 📣"
+DEFAULT_MODEL = os.getenv("OPENAI_STAFF_MODEL", "gpt-5")
+OPENAI_TIMEOUT = float(os.getenv("IASTAFF_TIMEOUT", "120"))
+MAX_OUTPUT_TOKENS = int(os.getenv("IASTAFF_MAX_OUTPUT_TOKENS", "1800"))
+DM_TIMEOUT = int(os.getenv("ANNONCE_DM_TIMEOUT", "300"))
+
+
+def extract_generated_text(resp_obj) -> str:
+    if isinstance(resp_obj, str):
+        return resp_obj
+    txt = ""
+    try:
+        data = resp_obj
+        if hasattr(resp_obj, "to_dict"):
+            data = resp_obj.to_dict()
+        elif hasattr(resp_obj, "dict"):
+            data = resp_obj.dict()
+        if isinstance(data, dict):
+            if "content" in data:
+                parts = data.get("content")
+                if isinstance(parts, list):
+                    for part in parts:
+                        if isinstance(part, dict):
+                            t = part.get("text") or part.get("content")
+                            if isinstance(t, str):
+                                txt += t
+                elif isinstance(data.get("content"), str):
+                    txt = data["content"]
+            elif isinstance(data.get("data"), list):
+                for item in data["data"]:
+                    txt += extract_generated_text(item)
+    except Exception:
+        pass
+    return txt.strip()
+
+
+class AnnonceCog(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.model = DEFAULT_MODEL
+        self.client = AsyncOpenAI(timeout=OPENAI_TIMEOUT) if AsyncOpenAI else None
+
+    @commands.command(name="*annonce")
+    @commands.has_role(STAFF_ROLE_NAME)
+    async def annonce_cmd(self, ctx: commands.Context):
+        if not self.client or not os.environ.get("OPENAI_API_KEY"):
+            await ctx.reply(
+                "❌ `OPENAI_API_KEY` n'est pas configurée sur l'hébergement. Ajoute la variable puis redeploie.",
+                mention_author=False,
+            )
+            return
+
+        dm = await ctx.author.create_dm()
+        await ctx.reply("📨 Je t'ai envoyé un DM pour préparer l'annonce.", mention_author=False)
+
+        system_prompt = (
+            "Tu es EvolutionBOT, assistant du staff de la guilde Évolution. "
+            "Pose successivement 7 questions brèves pour préparer une annonce. "
+            "Après la 7e réponse, rédige l'annonce finale en français, polie, stylée, "
+            "et commence par '@everyone'."
+        )
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": "Commence par la première question."},
+        ]
+        try:
+            resp = await self.client.responses.create(
+                model=self.model, messages=messages, max_output_tokens=MAX_OUTPUT_TOKENS
+            )
+            text = extract_generated_text(resp)
+        except Exception as e:
+            await dm.send(f"Erreur IA initiale : {e}")
+            return
+
+        await dm.send(text or "(aucune question)")
+
+        answers = 0
+        while answers < 7:
+            try:
+                user_msg = await self.bot.wait_for(
+                    "message",
+                    check=lambda m: m.author == ctx.author and m.channel == dm,
+                    timeout=DM_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                await dm.send("⏰ Temps écoulé, annulation.")
+                return
+            messages.append({"role": "user", "content": user_msg.content})
+            try:
+                resp = await self.client.responses.create(
+                    model=self.model, messages=messages, max_output_tokens=MAX_OUTPUT_TOKENS
+                )
+                text = extract_generated_text(resp)
+            except Exception as e:
+                await dm.send(f"Erreur IA : {e}")
+                return
+            answers += 1
+            if answers < 7:
+                await dm.send(text or "(aucune question)")
+            else:
+                final_announce = text.strip()
+                break
+
+        channel = discord.utils.get(ctx.guild.text_channels, name=ANNONCE_CHANNEL)
+        if not channel:
+            await dm.send(f"❌ Canal '{ANNONCE_CHANNEL}' introuvable.")
+            return
+        await channel.send(final_announce or "Annonce vide.")
+        await dm.send("✅ Annonce publiée dans #📣 annonces 📣.")
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(AnnonceCog(bot))

--- a/help.py
+++ b/help.py
@@ -160,6 +160,8 @@ class HelpCog(commands.Cog):
                 "> Liste des membres Staff enregistrés/mentionnés.\n\n"
                 "__**!annonce <texte>**__\n"
                 "> Publie une annonce stylée dans #📣 annonces 📣 (mention @everyone).\n\n"
+                "__**!*annonce**__\n"
+                "> L'IA pose 7 questions puis publie une annonce dans #📣 annonces 📣.\n\n"
                 "__**!event**__\n"
                 "> Lance une discussion privée pour planifier un événement.\n"
                 "> Après validation, un événement Discord programmé est créé et annoncé dans #🌈 organisation 🌈 (mention Membre validé).\n\n"

--- a/main.py
+++ b/main.py
@@ -123,6 +123,7 @@ class EvoBot(commands.Bot):
             "calcul",
             "defender",
             "moderation",
+            "annonce",
         ]
 
         for ext in base_exts:


### PR DESCRIPTION
## Summary
- add `!*annonce` command that converses with OpenAI to draft and post announcements
- load new `annonce` extension and document usage in help/README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b162c3125c832ebd84b7ae03400f2a