### PR TITLE
feat: rename staff announcement command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Pour que toutes les fonctionnalités fonctionnent correctement, le serveur doit 
 ### Salons textuels attendus
 - `console` : salon privé où le bot sauvegarde/charge ses fichiers JSON.
 - `ticket` : réception des tickets créés avec la commande `!ticket`.
-- `annonces` : utilisé par `!annonce`, `!*annonce` et pour les sondages.
+- `annonces` : utilisé par `!annonce`, `!annoncestaff` et pour les sondages.
 - `organisation` : pour la planification d'activités via `!activite`.
 - `𝐆𝐞́𝐧𝐞́𝐫𝐚𝐥` : canal public où le bot poste un message si les DM sont bloqués.
 - `𝐑𝐞𝐜𝐫𝐮𝐭𝐞𝐦𝐞𝐧𝐭` : annonces d'entrées ou de départs de la guilde.

--- a/annonce.py
+++ b/annonce.py
@@ -54,7 +54,7 @@ class AnnonceCog(commands.Cog):
         self.model = DEFAULT_MODEL
         self.client = AsyncOpenAI(timeout=OPENAI_TIMEOUT) if AsyncOpenAI else None
 
-    @commands.command(name="*annonce")
+    @commands.command(name="annoncestaff", aliases=["*annonce"])
     @commands.has_role(STAFF_ROLE_NAME)
     async def annonce_cmd(self, ctx: commands.Context):
         if not self.client or not os.environ.get("OPENAI_API_KEY"):

--- a/help.py
+++ b/help.py
@@ -160,7 +160,7 @@ class HelpCog(commands.Cog):
                 "> Liste des membres Staff enregistrés/mentionnés.\n\n"
                 "__**!annonce <texte>**__\n"
                 "> Publie une annonce stylée dans #📣 annonces 📣 (mention @everyone).\n\n"
-                "__**!*annonce**__\n"
+                "__**!annoncestaff**__\n"
                 "> L'IA pose 7 questions puis publie une annonce dans #📣 annonces 📣.\n\n"
                 "__**!event**__\n"
                 "> Lance une discussion privée pour planifier un événement.\n"


### PR DESCRIPTION
## Summary
- rename OpenAI-powered announcement command to `!annoncestaff`
- update help and README to reflect new staff announcement command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4cdd156d4832eaa95a3c440e13d57