### PR TITLE
Fix stats persistence and ladder data handling

### DIFF
--- a/tests/test_stats_store.py
+++ b/tests/test_stats_store.py
@@ -1,8 +1,8 @@
+import asyncio
 import os
 import sys
-import json
-import asyncio
 import types
+from itertools import count
 
 # Insert repo root in path
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -11,29 +11,68 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 fake_discord = sys.modules.setdefault("discord", types.ModuleType("discord"))
 fake_discord.Client = object
 
+
+class _Attachment:
+    def __init__(self, filename, data: bytes):
+        self.filename = filename
+        self._data = data
+
+    async def read(self):
+        return self._data
+
+
 class _Message:
-    def __init__(self, content="", author=None):
+    _ids = count(1)
+
+    def __init__(self, content="", author=None, attachments=None):
+        self.id = next(self._ids)
         self.content = content
         self.author = author
+        self.attachments = list(attachments or [])
         self.pinned = False
+        self.deleted = False
+
     async def edit(self, *, content=None):
         if content is not None:
             self.content = content
+
+    async def delete(self):
+        self.deleted = True
+
     async def pin(self, *, reason=None):
         self.pinned = True
+
 
 class _Channel:
     def __init__(self, name="console", messages=None, bot_user=None):
         self.name = name
         self._messages = list(messages or [])
         self.bot_user = bot_user
+
     async def history(self, limit=200):
-        for m in list(self._messages):
-            yield m
-    async def send(self, content):
-        m = _Message(content, author=self.bot_user)
-        self._messages.insert(0, m)
-        return m
+        yielded = 0
+        for msg in list(self._messages):
+            if yielded >= limit:
+                break
+            yielded += 1
+            yield msg
+
+    async def pins(self):
+        return [m for m in self._messages if getattr(m, "pinned", False)]
+
+    async def send(self, content, *, file=None):
+        attachments = []
+        if file is not None:
+            data = b""
+            path = getattr(file, "fp", None)
+            if isinstance(path, str) and os.path.exists(path):
+                with open(path, "rb") as fh:
+                    data = fh.read()
+            attachments.append(_Attachment(getattr(file, "filename", ""), data))
+        msg = _Message(content, author=self.bot_user, attachments=attachments)
+        self._messages.insert(0, msg)
+        return msg
+
 
 class _Utils:
     @staticmethod
@@ -48,19 +87,29 @@ class _Utils:
         import datetime
         return datetime.datetime.utcnow()
 
+
+class _File:
+    def __init__(self, fp, filename=None):
+        self.fp = fp
+        self.filename = filename
+
+
 fake_discord.Message = _Message
 fake_discord.TextChannel = _Channel
+fake_discord.File = _File
 fake_discord.Forbidden = type("Forbidden", (Exception,), {})
 fake_discord.NotFound = type("NotFound", (Exception,), {})
 fake_discord.utils = _Utils
 
 from utils.stats_store import StatsStore
 
+
 class _Bot:
     def __init__(self, channel):
         self._channel = channel
         self.user = object()
         channel.bot_user = self.user
+
     def get_all_channels(self):
         return [self._channel]
 
@@ -70,7 +119,18 @@ def test_stats_store_save_and_load(tmp_path):
     bot = _Bot(chan)
     store = StatsStore(bot)
     loop = asyncio.new_event_loop()
-    loop.run_until_complete(store.save({"val": 1}))
-    assert len(chan._messages) == 1
-    msg = chan._messages[0]
-    assert "\n  \"val\": 1" in msg.content
+    asyncio.set_event_loop(loop)
+    try:
+        saved = loop.run_until_complete(store.save({"val": 1}))
+        assert saved is True
+        assert len(chan._messages) == 1
+        msg = chan._messages[0]
+        assert msg.content.startswith("```json")
+
+        # simulate reload with a fresh store
+        new_store = StatsStore(bot)
+        loaded = loop.run_until_complete(new_store.load())
+        assert loaded == {"val": 1}
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)

--- a/utils/stats_store.py
+++ b/utils/stats_store.py
@@ -3,26 +3,33 @@
 
 import json
 import logging
-import tempfile
 import os
+import re
+import tempfile
+from typing import Optional
+
 import discord
 
 log = logging.getLogger("utils.stats_store")
 
+CODE_BLOCK_RE = re.compile(r"```(?:json)?\s*\n(?P<body>.+?)```", re.DOTALL)
+
 class StatsStore:
-    def __init__(self, bot, channel_name="console"):
+    def __init__(self, bot, channel_name: str = "console"):
         self.bot = bot
         self.channel_name = channel_name
         self._msg = None
 
     async def _get_channel(self):
-        return discord.utils.get(self.bot.get_all_channels(), name=self.channel_name)
+        chan = discord.utils.get(self.bot.get_all_channels(), name=self.channel_name)
+        if not chan:
+            log.warning("Canal #%s introuvable – persistance désactivée", self.channel_name)
+        return chan
 
-    async def save(self, data):
+    async def save(self, data) -> bool:
         chan = await self._get_channel()
         if not chan:
-            log.warning(f"Canal #{self.channel_name} introuvable – persistance désactivée")
-            return
+            return False
         payload = json.dumps(data, ensure_ascii=False, indent=2)
         content = f"```json\n{payload}\n```"
         if len(content) <= 2000:
@@ -31,9 +38,13 @@ class StatsStore:
                     await self._msg.edit(content=content)
                 else:
                     self._msg = await chan.send(content)
-            except:
-                self._msg = await chan.send(content)
-            return
+            except Exception:
+                try:
+                    self._msg = await chan.send(content)
+                except Exception:
+                    log.exception("Impossible d'enregistrer les stats dans #%s", self.channel_name)
+                    return False
+            return True
         fd, path = tempfile.mkstemp(suffix=".json")
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
@@ -44,10 +55,79 @@ class StatsStore:
                 except:
                     pass
                 self._msg = None
-            msg = await chan.send("===BOTSTATS=== (fichier)", file=discord.File(path, filename="stats_data.json"))
+            try:
+                msg = await chan.send(
+                    "===BOTSTATS=== (fichier)",
+                    file=discord.File(path, filename="stats_data.json"),
+                )
+            except Exception:
+                log.exception("Impossible d'envoyer le fichier de stats dans #%s", self.channel_name)
+                return False
             self._msg = msg
         finally:
             try:
                 os.remove(path)
             except:
                 pass
+        return True
+
+    async def load(self) -> Optional[dict]:
+        chan = await self._get_channel()
+        if not chan:
+            return None
+
+        checked: set[int] = set()
+
+        async def iter_candidates():
+            try:
+                for msg in await chan.pins():
+                    mid = getattr(msg, "id", id(msg))
+                    if mid in checked:
+                        continue
+                    checked.add(mid)
+                    yield msg
+            except Exception:
+                log.debug("Aucun pin exploitable pour #%s", self.channel_name)
+            async for msg in chan.history(limit=50):
+                mid = getattr(msg, "id", id(msg))
+                if mid in checked:
+                    continue
+                checked.add(mid)
+                yield msg
+
+        async for msg in iter_candidates():
+            data = await self._extract_payload(msg)
+            if data is not None:
+                self._msg = msg
+                return data
+        return None
+
+    async def _extract_payload(self, msg) -> Optional[dict]:
+        content = getattr(msg, "content", "") or ""
+        bot_user = getattr(self.bot, "user", None)
+        is_bot_message = bot_user is None or getattr(msg, "author", None) == bot_user
+        if not is_bot_message and "===BOTSTATS===" not in content:
+            return None
+
+        # Attachments first
+        for att in getattr(msg, "attachments", []) or []:
+            filename = getattr(att, "filename", "")
+            if not filename or not filename.endswith(".json"):
+                continue
+            try:
+                raw = await att.read()
+                return json.loads(raw.decode("utf-8"))
+            except Exception:
+                log.warning("Lecture JSON impossible depuis %s", filename, exc_info=True)
+
+        if not content:
+            return None
+        match = CODE_BLOCK_RE.search(content.strip())
+        if not match:
+            return None
+        body = match.group("body").strip()
+        try:
+            return json.loads(body)
+        except Exception:
+            log.warning("Contenu JSON invalide dans le message de stats", exc_info=True)
+            return None


### PR DESCRIPTION
## Summary
- normalise stats defaults into a reusable template and load persisted data from #console or a local fallback
- teach the StatsStore helper to reload messages/files from #console and report persistence failures cleanly
- extend the StatsStore test double so the new load path and behaviour are covered

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca5412e904832eafe7e5e8e8d3d204