### PR TITLE
Improve calendar navigation for activity command

### DIFF
--- a/calendrier.py
+++ b/calendrier.py
@@ -1,5 +1,8 @@
 import calendar
 import io
+from datetime import date
+from typing import Dict, Iterable, Optional
+
 import matplotlib
 
 matplotlib.use("Agg")
@@ -15,7 +18,28 @@ LIMITE_WRAP_TEXTE = 30
 ESPACEMENT_TITRE = 5
 RESOLUTION_DPI = 120
 
-def wrap_text(tx, mx=25):
+COULEUR_ENTETE = "#111827"
+COULEUR_ENTETE_TEXTE = "#F9FAFB"
+COULEUR_JOUR_EVENEMENT = "#DBEAFE"
+COULEUR_JOUR_AUJOURDHUI = "#2563EB"
+
+MONTH_NAMES_FR = [
+    "",
+    "Janvier",
+    "Février",
+    "Mars",
+    "Avril",
+    "Mai",
+    "Juin",
+    "Juillet",
+    "Août",
+    "Septembre",
+    "Octobre",
+    "Novembre",
+    "Décembre",
+]
+
+def wrap_text(tx: str, mx: int = 25) -> str:
     ls = []
     for ori in tx.split('\n'):
         l = ori.strip()
@@ -28,26 +52,52 @@ def wrap_text(tx, mx=25):
         ls.append(l)
     return "\n".join(x for x in ls if x)
 
-def gen_cal(data_events, bg, annee, mois):
-    evs = []
-    for _, e in data_events.items():
-        if e.cancelled:
-            continue
-        if e.date_obj.year == annee and e.date_obj.month == mois:
-            hs = e.date_obj.strftime("%Hh")
-            tx = e.titre if e.titre else "SansTitre"
-            line = "• " + hs + " " + tx
-            line = wrap_text(line, LIMITE_WRAP_TEXTE)
-            evs.append((e.date_obj.day, line))
 
-    dct = {}
-    for jour, txt in evs:
-        dct.setdefault(jour, []).append(txt)
+def _format_event_lines(events: Iterable) -> Dict[int, list[str]]:
+    """Prépare les lignes à afficher pour chaque jour."""
+
+    def _format_hour(dt):
+        return dt.strftime("%Hh") if dt.minute == 0 else dt.strftime("%Hh%M")
+
+    grouped: Dict[int, list[str]] = {}
+    for event in events:
+        titre = event.titre.strip() if getattr(event, "titre", None) else "Sans titre"
+        hour = _format_hour(event.date_obj)
+        line = f"• {hour} {titre}"
+        grouped.setdefault(event.date_obj.day, []).append(wrap_text(line, LIMITE_WRAP_TEXTE))
+    return grouped
+
+
+def gen_cal(data_events, bg, annee: int, mois: int, highlight_date: Optional[date] = None):
+    """
+    Génère une image PNG représentant un calendrier mensuel.
+
+    Args:
+        data_events: mapping d'événements `ActiviteData`.
+        bg: image de fond optionnelle (numpy array).
+        annee: année ciblée.
+        mois: mois ciblé (1-12).
+        highlight_date: date à mettre en avant (généralement la date du jour).
+    """
+
+    highlight_day = None
+    if highlight_date and highlight_date.year == annee and highlight_date.month == mois:
+        highlight_day = highlight_date.day
+
+    events_in_month = [
+        evt
+        for evt in data_events.values()
+        if not evt.cancelled and evt.date_obj.year == annee and evt.date_obj.month == mois
+    ]
+    events_in_month.sort(key=lambda evt: evt.date_obj)
+
+    day_lines = _format_event_lines(events_in_month)
 
     cal = calendar.Calendar(firstweekday=0)
     weeks = cal.monthdayscalendar(annee, mois)
 
-    table_txt = []
+    labs = ["Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"]
+    table_txt = [labs]
     for row in weeks:
         row_cells = []
         for d in row:
@@ -55,8 +105,8 @@ def gen_cal(data_events, bg, annee, mois):
                 row_cells.append("")
             else:
                 tcell = str(d)
-                if d in dct:
-                    for event_line in dct[d]:
+                if d in day_lines:
+                    for event_line in day_lines[d]:
                         tcell += "\n" + event_line
                 tcell = wrap_text(tcell, LIMITE_WRAP_TEXTE)
                 row_cells.append(tcell)
@@ -71,7 +121,6 @@ def gen_cal(data_events, bg, annee, mois):
     labs = ["Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"]
     table = ax.table(
         cellText=table_txt,
-        colLabels=labs,
         loc='center',
         cellLoc='center',
         zorder=1,
@@ -80,16 +129,43 @@ def gen_cal(data_events, bg, annee, mois):
     table.auto_set_font_size(False)
     table.set_fontsize(TAILLE_POLICE)
     table.scale(ECHELLE_CELLULE_X, ECHELLE_CELLULE_Y)
-    for _, cell in table.get_celld().items():
-        cell.set_facecolor("none")
-        cell.set_edgecolor("lightgray")
-        cell.set_linewidth(0.5)
-        txt = cell.get_text()
-        txt.set_clip_on(True)
-        txt.set_wrap(True)
+    # Ligne d'entête
+    for idx in range(len(labs)):
+        header = table[0, idx]
+        header.set_facecolor(COULEUR_ENTETE)
+        header.set_edgecolor("#1F2937")
+        text = header.get_text()
+        text.set_color(COULEUR_ENTETE_TEXTE)
+        text.set_weight('bold')
+        text.set_clip_on(True)
+        text.set_wrap(False)
+
+    event_days = set(day_lines)
+    for row_idx, week in enumerate(weeks, start=1):
+        for col_idx, day in enumerate(week):
+            cell = table[row_idx, col_idx]
+            cell.set_edgecolor("lightgray")
+            cell.set_linewidth(0.5)
+            txt = cell.get_text()
+            txt.set_clip_on(True)
+            txt.set_wrap(True)
+
+            if day == 0:
+                cell.set_facecolor("none")
+                continue
+
+            if highlight_day and day == highlight_day:
+                cell.set_facecolor(COULEUR_JOUR_AUJOURDHUI)
+                txt.set_color("#FFFFFF")
+            elif day in event_days:
+                cell.set_facecolor(COULEUR_JOUR_EVENEMENT)
+                txt.set_color("#111827")
+            else:
+                cell.set_facecolor("none")
+                txt.set_color("#111827")
 
     ax.set_title(
-        calendar.month_name[mois] + " " + str(annee),
+        MONTH_NAMES_FR[mois] + " " + str(annee),
         fontsize=16,
         fontweight='bold',
         pad=ESPACEMENT_TITRE


### PR DESCRIPTION
## Summary
- restyle the calendar generator with French month names, event highlighting and better text formatting
- replace the reaction-driven `!calendrier` command by an interactive button view with month navigation and inline stats
- add a reusable `CalendrierView` helper to manage updates, permissions and lifecycle of the calendar message

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa963f4e8832e988339c81a686085