### PR TITLE
Fix players initialization deadlock

### DIFF
--- a/welcome.py
+++ b/welcome.py
@@ -208,7 +208,7 @@ class WelcomeCog(commands.Cog):
 
         players_cog = self.bot.get_cog("PlayersCog")
         if players_cog:
-            players_cog.auto_register_member(
+            await players_cog.auto_register_member(
                 discord_id=member.id,
                 discord_display_name=member.display_name,
                 dofus_pseudo=dofus_pseudo


### PR DESCRIPTION
## Summary
- avoid waiting for readiness inside the players cog load by spawning an async initialization task guarded by a lock
- ensure member commands/events wait for the initialization task and make auto-registration async so that data persistence happens after the bot is ready
- update the welcome workflow to await the players auto-registration helper when onboarding new members

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68caac41c9ac832eb12d65004c44ee0c