### PR TITLE
Fix annonce command channel lookup

### DIFF
--- a/ia.py
+++ b/ia.py
@@ -116,7 +116,7 @@ class IACog(commands.Cog):
         self.quota_block_duration = 3600
         self.quota_exceeded_until = 0
         self.debug_mode = True
-        self.annonce_channel_name = "📣 annonces 📣"
+        self.annonce_channel_name = os.getenv("ANNONCE_CHANNEL_NAME", "annonces")
         self.event_channel_name = "🌈 organisation 🌈"
         self.pl_channel_name = "📍 xplock-rondesasa-ronde 📍"
         self.last_reglement_reminder = 0
@@ -490,6 +490,13 @@ class IACog(commands.Cog):
             await ctx.send("Usage: !annonce <texte>")
             return
         chan = discord.utils.get(ctx.guild.text_channels, name=self.annonce_channel_name)
+        if not chan:
+            legacy_names = {"📣 annonces 📣", "annonces"}
+            legacy_names.discard(self.annonce_channel_name)
+            for legacy in legacy_names:
+                chan = discord.utils.get(ctx.guild.text_channels, name=legacy)
+                if chan:
+                    break
         if not chan:
             await ctx.send(f"Canal '{self.annonce_channel_name}' introuvable.")
             return


### PR DESCRIPTION
## Summary
- read the annonce channel name from the ANNONCE_CHANNEL_NAME environment variable to match the rest of the bot
- add a legacy name fallback so the IA announcement command still works if the channel keeps its old emoji name

## Testing
- pytest tests/test_annonce_command.py

------
https://chatgpt.com/codex/tasks/task_e_68d75a61e444832ea50b04726b480dc2