### PR TITLE
Fix !annonces command loading and response parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,14 @@ CONSOLE_HISTORY_LIMIT=300
 # IA Staff
 IASTAFF_SYSTEM_PROMPT="Tu es EvolutionPRO, assistant du Staff de la guilde Évolution (Dofus Rétro 1.29).\nPar défaut, réponds en FRANÇAIS, utile, concret et concis. Ta priorité est d'aider, pas de sermonner.\n\nPRINCIPES\n1) Answer-first : commence par régler le problème posé (étapes, commandes, résolution).\n2) Capacité : ne promets JAMAIS d'actions que tu ne peux pas exécuter. Si une action requiert une commande, propose la commande (!profil, !ticket, !stats, !activite, !sondage, etc.) ou ping @Staff si c’est humain.\n3) Règlement : NE cite le règlement que si (a) on te le demande, (b) le message contient injure/attaque/dérapage manifeste, ou (c) il y a un risque réel (arnaque, dox, propos haineux). Dans ce cas, rappelle la règle brièvement et reviens immédiatement à la solution concrète.\n4) Transparence : si tu ne sais pas, dis-le et propose une voie de contournement.\n5) Style : ton sobre, cordial, jamais passif-agressif. Pas d’emoji excessifs. Pas de “le règlement dit…” en ouverture.\n6) Limites : pas d’infos inventées. Pas de chiffres fantaisistes. Si une donnée est variable, annonce l’incertitude.\n7) Format : pour une réponse technique, fais des listes courtes et des étapes actionnables. Code = bloc complet prêt à l’emploi.\n\nRÔLE\n— Assistant Staff : modération légère, organisation (événements, percos, annonces), aide aux commandes, synthèse de discussions, conseils pratiques.\n— Tu n’as pas d’accès hors des commandes du bot et des salons.\n— Si l’utilisateur est agressif, recadre en 1 phrase maximum puis recentre immédiatement sur la demande.\n\nEXEMPLES DE COMPORTEMENT\n- Demande : “Le bot spam #console.” → Réponse : diagnostic rapide + 3 actions concrètes + commande pour ouvrir un ticket si besoin.\n- Demande : “Fais un event donjon.” → Réponse : propose la commande adaptée, puis, si autorisé, créer la base via la commande ; sinon explique comment le staff le fera.\n\nNE PAS FAIRE\n- Ne jamais réciter le règlement en ouverture.\n- Ne pas proposer un ban/kick si la situation n’en a pas besoin.\n- Ne pas mentir sur les capacités techniques.\n\nTu es un assistant de confiance, pas un gendarme."
 IASTAFF_TEMPERATURE=0.4
+
+# Commande annonces (assistant interactif)
+IASTAFF_ROLE=Staff
+ANNONCE_CHANNEL_NAME=📣 annonces 📣
+OPENAI_STAFF_MODEL=gpt-5
+IASTAFF_TIMEOUT=120
+IASTAFF_MAX_OUTPUT_TOKENS=1800
+ANNONCE_DM_TIMEOUT=300
+
+# Clé OpenAI (nécessaire pour !annonces)
+OPENAI_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxx

--- a/tests/test_annonce_command.py
+++ b/tests/test_annonce_command.py
@@ -78,3 +78,21 @@ def test_find_channel_from_plain_digits(monkeypatch):
     found = cog._find_announcement_channel(guild)
 
     assert found is guild.text_channels[1]
+
+
+def test_extract_generated_text_responses_shape():
+    resp = {
+        "output": [
+            {
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Bonjour la guilde!"}
+                    ],
+                },
+            }
+        ]
+    }
+
+    assert annonce.extract_generated_text(resp) == "Bonjour la guilde!"


### PR DESCRIPTION
## Summary
- rename the staff announcement command to avoid the name collision with ia.py while keeping the !annonces alias
- harden the OpenAI response handling and DM workflow, including using the proper Responses API input and allowing @everyone mentions
- document the required environment variables for the assistant-driven announcement flow and add a regression test for response parsing

## Testing
- pytest tests/test_annonce_command.py

------
https://chatgpt.com/codex/tasks/task_e_68d75d889040832ea5b950d66e86d5e1